### PR TITLE
Update partitioning scheme to put swap first

### DIFF
--- a/http/jessie.preseed.cfg
+++ b/http/jessie.preseed.cfg
@@ -14,7 +14,25 @@ d-i mirror/http/directory string /debian
 d-i mirror/http/hostname string http.debian.net
 d-i mirror/http/proxy string
 d-i partman-auto/method string regular
-d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/expert_recipe string \
+    200% 200% 200% linux-swap         \
+        $primary{ }                   \
+        method{ swap }                \
+        format{ }                     \
+        label{ SWAP }                 \
+    .                                 \
+                                      \
+    10240 30720 -1 ext4               \
+        $primary{ }                   \
+        $bootable{ }                  \
+        method{ format }              \
+        format{ }                     \
+        use_filesystem{ }             \
+        filesystem{ ext4 }            \
+        mountpoint{ / }               \
+        label{ ROOT }                 \
+    .                                 \
+
 d-i partman/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true

--- a/jessie.json
+++ b/jessie.json
@@ -9,7 +9,7 @@
 
       "vm_name": "debian",
       "cpus": 2,
-      "disk_size": 10000,
+      "disk_size": 40000,
       "memory": 4096,
 
       "guest_os_type": "Debian_64",


### PR DESCRIPTION
The default layout of the atomic scheme is that swap comes second.
This becomes a problem is when provisioning on large VM disks as the
swap partition sits between the root partition and the free space.

Putting the root after the swap, it is now easy to grow the root to the
available space.

Also updated is the disk image size. 